### PR TITLE
avoid deprecated C macro API in build script

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -828,7 +828,7 @@ fn configureGlslangBinary(compile: *std.Build.Step.Compile, enable_opt: bool) vo
     compile.addIncludePath(glslang_upstream.path(""));
     compile.addIncludePath(b.path("generated/glslang"));
 
-    compile.defineCMacro("ENABLE_OPT", if (enable_opt) "1" else "0");
+    compile.root_module.addCMacro("ENABLE_OPT", if (enable_opt) "1" else "0");
 }
 
 fn configureGlslangLibrary(lib: *std.Build.Step.Compile, enable_opt: bool) void {


### PR DESCRIPTION
deprecated API removed in https://github.com/ziglang/zig/pull/20388

Tested with `0.14.0-dev.2548+0f17cbfc6`.

Before:

```
andy@bark ~/s/glslang-zig (main)> zig build
/home/andy/src/glslang-zig/build.zig:831:12: error: no field or member function named 'defineCMacro' in 'Build.Step.Compile'
    compile.defineCMacro("ENABLE_OPT", if (enable_opt) "1" else "0");
    ~~~~~~~^~~~~~~~~~~~~
```

After: successful build